### PR TITLE
Fix for non-app.speckle.systems servers

### DIFF
--- a/src/speckleifc/__main__.py
+++ b/src/speckleifc/__main__.py
@@ -94,7 +94,9 @@ def open_and_convert_file(
     print(f"Sending to speckle complete after: {(time.time() - start) * 1000}ms")
 
     start = time.time()
-    client = SpeckleClient()
+    server_url = account.serverInfo.url
+    assert server_url
+    client = SpeckleClient(host=server_url)
     client.authenticate_with_account(account)
 
     create_version = CreateVersionInput(


### PR DESCRIPTION
Due to a frustratingly not obvious behaviour of the `SpeckleClient.authenticate_with_account` function, the importer was failing because it was trying to create a commit on app.speckle.systems rather than the server url defined by the the account object
 