### PR TITLE
Rendermaterials inherit material names instead of type + unique id

### DIFF
--- a/src/speckleifc/ifc_geometry_processing.py
+++ b/src/speckleifc/ifc_geometry_processing.py
@@ -15,6 +15,8 @@ def _create_iterator_settings() -> settings:
     ifc_settings.set("use-world-coords", True)
     # Tiny performance improvement,
     ifc_settings.set("no-wire-intersection-check", True)
+    # Rendermaterials inherit the material names instead of type + unique id
+    ifc_settings.set("use-material-names", True)
 
     # IfcOpenshell defaults to 0.001mm here, which leads to very dense meshes.
     # lowering the mesh quality a bit here leads to meshes


### PR DESCRIPTION
Hi, thanks for the new Importer!
I am really happy to see the switch to IfcOpenShell - awesome!

It would be nice to preserve the original material and style names. 
In our usecase we are trying to associate different textures and it would be so helpful to have "Wood Birch" instead of "IfcSurfaceStyleRendering-22632" as a name.

The PR just enables the "use-material-names" flag on the geometry iterator which seems to do the trick.
On the flipside, the information about the original ifc type will get lost in this case but i would expect this information in a "ifcType" property on the material if at all.

Thanks a lot!